### PR TITLE
Fix mdatahandle crash for pnts

### DIFF
--- a/meshChecker/src/meshChecker.cpp
+++ b/meshChecker/src/meshChecker.cpp
@@ -160,18 +160,17 @@ bool MeshChecker::hasVertexPntsAttr() {
         while (true) {
             outputHandle = arrayDataHandle.outputValue();
             float3& xyz = outputHandle.asFloat3();
-            if (!xyz) {
-                return false;
+            if (xyz) {
+                if (xyz[0] != 0.0)
+                    pntsArray.destructHandle(dataHandle);
+                    return true;
+                if (xyz[1] != 0.0)
+                    pntsArray.destructHandle(dataHandle);
+                    return true;
+                if (xyz[2] != 0.0)
+                    pntsArray.destructHandle(dataHandle);
+                    return true;
             }
-            if (xyz[0] != 0.0)
-                pntsArray.destructHandle(dataHandle);
-                return true;
-            if (xyz[1] != 0.0)
-                pntsArray.destructHandle(dataHandle);
-                return true;
-            if (xyz[2] != 0.0)
-                pntsArray.destructHandle(dataHandle);
-                return true;
             status = arrayDataHandle.next();
             if (status != MS::kSuccess) {
                 break;

--- a/meshChecker/src/meshChecker.cpp
+++ b/meshChecker/src/meshChecker.cpp
@@ -160,11 +160,17 @@ bool MeshChecker::hasVertexPntsAttr() {
         while (true) {
             outputHandle = arrayDataHandle.outputValue();
             float3& xyz = outputHandle.asFloat3();
+            if (!xyz) {
+                return false;
+            }
             if (xyz[0] != 0.0)
+                pntsArray.destructHandle(dataHandle);
                 return true;
             if (xyz[1] != 0.0)
+                pntsArray.destructHandle(dataHandle);
                 return true;
             if (xyz[2] != 0.0)
+                pntsArray.destructHandle(dataHandle);
                 return true;
             status = arrayDataHandle.next();
             if (status != MS::kSuccess) {
@@ -202,6 +208,7 @@ bool MeshChecker::hasVertexPntsAttr() {
         }
         pntsArray.setMDataHandle(dataHandle);
     }
+    pntsArray.destructHandle(dataHandle);
 
     return false;
 }

--- a/meshChecker/src/pluginMain.cpp
+++ b/meshChecker/src/pluginMain.cpp
@@ -3,7 +3,7 @@
 
 MStatus initializePlugin(MObject mObj)
 {
-    MFnPlugin fnPlugin(mObj, "Michitaka Inoue", "1.1.4", "Any");
+    MFnPlugin fnPlugin(mObj, "Michitaka Inoue", "1.1.5", "Any");
     fnPlugin.registerCommand("checkMesh", MeshChecker::creator, MeshChecker::newSyntax);
     return MS::kSuccess;
 }


### PR DESCRIPTION
If the user never moved vertexes of a mesh, the mesh will not have pnts (tweak points) attributes created.
We need to check this or the plugin will crash.
To confirm the crash, create a sphere, run the meshChecker c=9.